### PR TITLE
Add types and documentation for Rule.resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -1156,6 +1156,29 @@ config.module
         .loader('sass-vars-to-js-loader')
 ```
 
+#### Config module rules resolve
+
+Specify a resolve configuration to be merged over the default `config.resolve`
+for modules that match the rule.
+
+See "Config resolve" sections above for full syntax.
+
+**Note:** This option is supported by webpack since 4.36.1.
+
+```js
+config.module
+  .rule(name)
+    .resolve
+
+// Example
+
+config.module
+  .rule('scss')
+    .test(/\.scss$/)
+    .resolve
+      .symlinks(true)
+```
+
 ---
 
 ### Merging Config

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -199,7 +199,7 @@ declare namespace Config {
 
   class EntryPoint extends TypedChainedSet<Config, string> {}
 
-  class Resolve extends ChainedMap<Config> {
+  class Resolve<T = Config> extends ChainedMap<T> {
     alias: TypedChainedMap<this, string>;
     aliasFields: TypedChainedSet<this, string>;
     descriptionFiles: TypedChainedSet<this, string>;
@@ -230,6 +230,7 @@ declare namespace Config {
     uses: TypedChainedMap<this, Use>;
     include: TypedChainedSet<this, webpack.Condition>;
     exclude: TypedChainedSet<this, webpack.Condition>;
+    resolve: Resolve<Rule<T>>;
 
     parser(value: { [optName: string]: any }): this;
     test(value: webpack.Condition | webpack.Condition[]): this;

--- a/types/test/webpack-chain-tests.ts
+++ b/types/test/webpack-chain-tests.ts
@@ -319,6 +319,9 @@ config
         .use('url')
           .loader('url-loader')
           .end()
+        .resolve
+          .symlinks(true)
+          .end()
         .end()
       .rules
         .delete('inline')
@@ -335,6 +338,9 @@ config
         .end()
       .oneOfs
         .delete('inline')
+        .end()
+      .resolve
+        .symlinks(true)
         .end()
       .end()
     .rules


### PR DESCRIPTION
Adds the missing types and documentation mentioned in neutrinojs/webpack-chain#265.